### PR TITLE
Derive macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: rust
+rust: nightly
+cache:
+    - cargo
+before_script:
+    - rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
+script:
+    - cargo +nightly fmt --all -- --check
+    - cargo test

--- a/abgc_derive/Cargo.toml
+++ b/abgc_derive/Cargo.toml
@@ -4,4 +4,12 @@ version = "0.1.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 edition = "2018"
 
+[lib]
+proc-macro = true
+
 [dependencies]
+syn = "0.15"
+quote = "0.6"
+
+[dev-dependencies]
+abgc = { path="../abgc" }

--- a/abgc_derive/src/lib.rs
+++ b/abgc_derive/src/lib.rs
@@ -1,7 +1,30 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+extern crate proc_macro;
+
+use crate::proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(GcLayout)]
+pub fn gclayout_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let expanded = quote! {
+        impl #impl_generics ::abgc::GcLayout for #ident #ty_generics #where_clause {
+            fn layout(&self) -> ::std::alloc::Layout {
+                ::std::alloc::Layout::new::<#ident<#ty_generics>>()
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
 }

--- a/abgc_derive/tests/derive.rs
+++ b/abgc_derive/tests/derive.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use abgc::Gc;
+use abgc_derive::GcLayout;
+
+#[test]
+fn test_derive() {
+    #[derive(GcLayout)]
+    struct S(u64);
+
+    let s = Gc::new(S(42));
+    assert_eq!(s.0, 42);
+}


### PR DESCRIPTION
This adds a simple `GcLayout` derive proc macro that means that most users now need only say `#[derive(GcLayout)]` rather than having to manually `impl GcLayout for ...`.

@jacob-hughes might also find this mildly interesting.