### PR TITLE
The quote library automatically adds angled brackets.

### DIFF
--- a/abgc_derive/src/lib.rs
+++ b/abgc_derive/src/lib.rs
@@ -21,7 +21,7 @@ pub fn gclayout_derive(input: TokenStream) -> TokenStream {
     let expanded = quote! {
         impl #impl_generics ::abgc::GcLayout for #ident #ty_generics #where_clause {
             fn layout(&self) -> ::std::alloc::Layout {
-                ::std::alloc::Layout::new::<#ident<#ty_generics>>()
+                ::std::alloc::Layout::new::<#ident #ty_generics>()
             }
         }
     };


### PR DESCRIPTION
By adding in angled brackets ourselves, we ended up causing bizarre parsing errors if, and only if, the struct/enum we used the proc macro on had lifetimes.