### PR TITLE
Add explicit licenses in Cargo.toml.

### DIFF
--- a/abgc/Cargo.toml
+++ b/abgc/Cargo.toml
@@ -3,5 +3,6 @@ name = "abgc"
 version = "0.1.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [dependencies]

--- a/abgc_derive/Cargo.toml
+++ b/abgc_derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "abgc_derive"
 version = "0.1.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 edition = "2018"
+license = "Apache-2.0/MIT"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
This makes it easier for automatic license checking tools to work.